### PR TITLE
Stringify JSON request body for content MD5.

### DIFF
--- a/src/execute/oas3/build-request.js
+++ b/src/execute/oas3/build-request.js
@@ -171,6 +171,10 @@ const CONTENT_TYPE = 'application/json'
 
 function md5(requestBody) {
   if (requestBody) {
+    if (isPlainObject(requestBody) || isArray(requestBody)) {
+      requestBody = JSON.stringify(requestBody)
+    }
+    
     return crypto.createHash('md5').update(requestBody).digest('base64')
   }
   return ''


### PR DESCRIPTION
`requestBody` passed to `md5()` function is actually JS object and not a string.